### PR TITLE
fix:added the missing vecel.json file

### DIFF
--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
This pull request introduces a small configuration change to the `ui/vercel.json` file. The change adds a rewrite rule to redirect all incoming requests to the root path.

* [`ui/vercel.json`](diffhunk://#diff-365cdb647e7562a5f803546aa64ba9782333b35fa9b7a6b43b044b17dcd2bad8R1-R3): Added a rewrite rule to redirect requests matching `/(.*)` to `/`.