### PR TITLE
added extra validation for mongo db object Id's

### DIFF
--- a/backend/src/schema/agents.ts
+++ b/backend/src/schema/agents.ts
@@ -22,9 +22,9 @@ export const AgentSchema = z.object({
 export const AgentUpdateSchema = AgentSchema.partial();
 
 export const AgentIdParamSchema = z.object({
-  id: z.string() /*.refine(isValidObjectId, {
+  id: z.string().refine(isValidObjectId, {
     message: "Invalid agent ID format",
-  }),*/,
+  }),
 });
 
 export type Agent = z.infer<typeof AgentSchema>;


### PR DESCRIPTION
This pull request includes a minor update to the `AgentIdParamSchema` in the `backend/src/schema/agents.ts` file. The change re-enables the `.refine` method to validate the `id` field, ensuring it adheres to the `isValidObjectId` format.

Validation improvement:

* [`backend/src/schema/agents.ts`](diffhunk://#diff-737e55a6d5e426bca9e89429aab3a078465e6240651c6a219c721040e762789dL25-R27): Re-enabled the `.refine` method for the `id` field in `AgentIdParamSchema`, which validates the ID format using `isValidObjectId` and provides an appropriate error message.