### PR TITLE
added time to messages

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -31,6 +31,7 @@
     "axios": "^1.8.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "framer-motion": "^12.7.4",
     "lucide-react": "^0.476.0",
     "motion": "^12.7.4",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       framer-motion:
         specifier: ^12.7.4
         version: 12.7.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2513,6 +2516,9 @@ packages:
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -8491,6 +8497,8 @@ snapshots:
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.27.0
+
+  date-fns@4.1.0: {}
 
   dateformat@4.6.3: {}
 

--- a/ui/src/components/ui/chat-messsage.tsx
+++ b/ui/src/components/ui/chat-messsage.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
-import { Bot, User } from "lucide-react";
+import { Bot, User, Clock } from "lucide-react";
 import type { Message } from "./chat-drawer";
-
+import { format } from "date-fns";
 interface ChatMessageProps {
   message: Message;
 }
@@ -24,13 +24,24 @@ const ChatMessage = ({ message }: ChatMessageProps) => {
       >
         {isAI ? <Bot className="h-4 w-4" /> : <User className="h-4 w-4" />}
       </div>
-      <div
-        className={cn(
-          "rounded-lg px-4 py-2 max-w-[80%]",
-          isAI ? "bg-muted" : "bg-primary text-primary-foreground",
-        )}
-      >
-        <p className="text-sm">{message.content}</p>
+      <div className="max-w-[80%] flex flex-col gap-2">
+        <div
+          className={cn(
+            "rounded-lg px-4 py-2 ",
+            isAI ? "bg-muted" : "bg-primary text-primary-foreground",
+          )}
+        >
+          <p className="text-sm">{message.content}</p>
+        </div>
+        <div
+          className={cn(
+            "flex mx-2  items-center gap-1 text-xs text-muted-foreground",
+            isAI ? "self-start" : "self-end",
+          )}
+        >
+          <Clock className="h-3 w-3" />
+          <span>{format(message.timestamp, "HH:mm")}</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request introduces the `date-fns` library to the project and updates the `ChatMessage` component to display message timestamps in a user-friendly format. Below are the key changes grouped by theme:

### Dependency Updates:
* Added `date-fns` version `^4.1.0` to `ui/package.json` and updated `ui/pnpm-lock.yaml` to include the dependency in the `importers`, `packages`, and `snapshots` sections. [[1]](diffhunk://#diff-193b27d62e4fbda3d563009fed5ec6761a05f73558d94b39fab63ae948c679eaR34) [[2]](diffhunk://#diff-ac1b2ae9a24d70de502f52a85a33ba5e7726cd17f206ac5f99c15f86271001f2R79-R81) [[3]](diffhunk://#diff-ac1b2ae9a24d70de502f52a85a33ba5e7726cd17f206ac5f99c15f86271001f2R2520-R2522) [[4]](diffhunk://#diff-ac1b2ae9a24d70de502f52a85a33ba5e7726cd17f206ac5f99c15f86271001f2R8501-R8502)

### UI Enhancements:
* Updated the `ChatMessage` component in `ui/src/components/ui/chat-messsage.tsx` to use `date-fns` for formatting message timestamps. Added a new timestamp display below each message, styled with a clock icon and formatted as "HH:mm". [[1]](diffhunk://#diff-a8f521c312b873a966ffca97deb370eeaf14168a5a3e704ab72ce474edc0cc2dL2-R4) [[2]](diffhunk://#diff-a8f521c312b873a966ffca97deb370eeaf14168a5a3e704ab72ce474edc0cc2dR27-R45)